### PR TITLE
Add q value multiple testing correction

### DIFF
--- a/docs/02_analysis.fsx
+++ b/docs/02_analysis.fsx
@@ -53,6 +53,7 @@ You can control the following parameters used during the analysis by passing `TM
 #r "nuget: FSharp.Data, 4.1.1"
 open FSharp.Data
 open TMEA
+open TMEA.Frames
 open Deedle
 open TMEA.IO
 
@@ -124,7 +125,7 @@ The contents of this frame indicate for every functionally annotated set in each
 let sigFrame = 
     tmeaResult
     |> TMEAResult.toSignificanceMatrixFrame(
-        UseBenjaminiHochberg = true,
+        CorrectionMethod = MultipleTestingCorrection.BenjaminiHochberg,
         AlphaLevel = 0.05
     )
 

--- a/src/TMEA/Frames.fs
+++ b/src/TMEA/Frames.fs
@@ -9,6 +9,12 @@ module Frames =
         | NoCorrection
         | BenjaminiHochberg
         | QValues
+        static member toString  =
+            function
+            | NoCorrection -> "noCorrection"
+            | BenjaminiHochberg -> "BH"
+            | QValues -> "QValues"
+        override this.ToString() = this |> MultipleTestingCorrection.toString
 
     let internal optDefFloat (f:float opt)=
         if f.HasValue then f.Value else -1.
@@ -17,6 +23,9 @@ module Frames =
         if f.HasValue then f.Value else 0
 
     let internal createTMEACharacterizationTable minBinSize (alphaLevel:float) (termNameTransformation: string -> string) (multipleTestingCorrection: MultipleTestingCorrection)  (tmeaCharacterizations:TMEACharacterization []): Frame<(string*(string*int)),string> =
+        
+        let correctionDescripton = multipleTestingCorrection.ToString()
+        
         tmeaCharacterizations
         |> Array.mapi (fun i desc ->
             let negFrame: Frame<string,string> =
@@ -100,12 +109,12 @@ module Frames =
                 |> series
         
             f
-            |> Frame.addCol "Pos_PValue_Corrected" correctedPosPVals
-            |> Frame.addCol "Neg_PValue_Corrected" correctedNegPVals
+            |> Frame.addCol $"Pos_PValue_{correctionDescripton}_Corrected" correctedPosPVals
+            |> Frame.addCol $"Neg_PValue_{correctionDescripton}_Corrected" correctedNegPVals
             |> Frame.mapRowKeys (fun (name,cI) -> (termNameTransformation name) => (name,cI))
             |> fun f ->
                 let allPvalZip =
-                    Series.zip (f |> Frame.getCol "Neg_PValue_Corrected") (f |> Frame.getCol "Pos_PValue_Corrected")
+                    Series.zip (f |> Frame.getCol $"Neg_PValue_{correctionDescripton}_Corrected") (f |> Frame.getCol $"Pos_PValue_{correctionDescripton}_Corrected")
                     |> Series.mapAll (fun _ (x:(float opt * float opt) option) ->
                         let p1,p2 =
                             match x with 

--- a/src/TMEA/Frames.fs
+++ b/src/TMEA/Frames.fs
@@ -4,6 +4,11 @@ module Frames =
 
     open Deedle
     open FSharp.Stats
+    
+    type MultipleTestingCorrection =
+        | NoCorrection
+        | BenjaminiHochberg
+        | QValues
 
     let internal optDefFloat (f:float opt)=
         if f.HasValue then f.Value else -1.
@@ -11,7 +16,7 @@ module Frames =
     let internal optDefInt (f:int opt)=
         if f.HasValue then f.Value else 0
 
-    let internal createTMEACharacterizationTable minBinSize (alphaLevel:float) (termNameTransformation: string -> string) (tmeaCharacterizations:TMEACharacterization []) : Frame<(string*(string*int)),string> =
+    let internal createTMEACharacterizationTable minBinSize (alphaLevel:float) (termNameTransformation: string -> string) (multipleTestingCorrection: MultipleTestingCorrection)  (tmeaCharacterizations:TMEACharacterization []): Frame<(string*(string*int)),string> =
         tmeaCharacterizations
         |> Array.mapi (fun i desc ->
             let negFrame: Frame<string,string> =
@@ -60,22 +65,47 @@ module Frames =
                 f |> Frame.getCol "Neg_PValue" |> Series.observations |> Seq.groupBy (fun ((bin,constrIndex),(pValue:float)) -> constrIndex)
             let correctedPosPVals, correctedNegPVals =
                 posPVals 
-                |> Seq.map (fun (cI,pVals) -> pVals |> FSharp.Stats.Testing.MultipleTesting.benjaminiHochbergFDRBy id)
+                |> Seq.map (fun (cI,pVals) -> 
+                    match multipleTestingCorrection with
+                    | NoCorrection -> pVals |> List.ofSeq
+                    | BenjaminiHochberg -> 
+                        pVals 
+                        |> FSharp.Stats.Testing.MultipleTesting.benjaminiHochbergFDRBy id
+                    | QValues -> 
+                        let id,pv = pVals |> Array.ofSeq |> Array.unzip
+                        let pi0 = Testing.MultipleTesting.Qvalues.pi0Bootstrap pv
+                        let qv = Testing.MultipleTesting.Qvalues.ofPValues pi0 pv
+                        Array.zip id qv
+                        |> List.ofArray
+                    )
                 |> Seq.concat
                 |> series
                 ,
                 negPVals 
-                |> Seq.map (fun (cI,pVals) -> pVals |> FSharp.Stats.Testing.MultipleTesting.benjaminiHochbergFDRBy id)
+                |> Seq.map (fun (cI,pVals) -> 
+                    match multipleTestingCorrection with
+                    | NoCorrection -> pVals |> List.ofSeq
+                    | BenjaminiHochberg -> 
+                        pVals 
+                        |> FSharp.Stats.Testing.MultipleTesting.benjaminiHochbergFDRBy id
+                    | QValues -> 
+                        let id,pv = pVals |> Array.ofSeq |> Array.unzip
+                        let pi0 = Testing.MultipleTesting.Qvalues.pi0Bootstrap pv
+                        let qv = Testing.MultipleTesting.Qvalues.ofPValues pi0 pv
+                        Array.zip id qv
+                        |> List.ofArray
+                    )
+                    
                 |> Seq.concat
                 |> series
         
             f
-            |> Frame.addCol "Pos_PValue_BH_Corrected" correctedPosPVals
-            |> Frame.addCol "Neg_PValue_BH_Corrected" correctedNegPVals
+            |> Frame.addCol "Pos_PValue_Corrected" correctedPosPVals
+            |> Frame.addCol "Neg_PValue_Corrected" correctedNegPVals
             |> Frame.mapRowKeys (fun (name,cI) -> (termNameTransformation name) => (name,cI))
             |> fun f ->
                 let allPvalZip =
-                    Series.zip (f |> Frame.getCol "Neg_PValue_BH_Corrected") (f |> Frame.getCol "Pos_PValue_BH_Corrected")
+                    Series.zip (f |> Frame.getCol "Neg_PValue_Corrected") (f |> Frame.getCol "Pos_PValue_Corrected")
                     |> Series.mapAll (fun _ (x:(float opt * float opt) option) ->
                         let p1,p2 =
                             match x with 
@@ -87,7 +117,7 @@ module Frames =
                         || (p2 < alphaLevel && p2 >= 0.))
                         |> Some
                     )
-                f |> Frame.addCol "isAnySig_BH_Corrected" allPvalZip
+                f |> Frame.addCol "isAnySig_Corrected" allPvalZip
             |> fun f ->
                 let allPvalZip =
                     Series.zip (f |> Frame.getCol "Neg_PValue") (f |> Frame.getCol "Pos_PValue")
@@ -131,11 +161,11 @@ module Frames =
         ///
         /// Total_BinSize - The amount of entities contained in the FAS
         ///
-        /// Pos_PValue_BH_Corrected - The afforementioned positive p-value, constraint-wise adjusted with the Benjamini-Hochberg correction for multiple testing
+        /// Pos_PValue_Corrected - The afforementioned positive p-value, constraint-wise adjusted with the Benjamini-Hochberg correction for multiple testing
         ///
-        /// Neg_PValue_BH_Corrected - The afforementioned negative p-value, constraint-wise adjusted with the Benjamini-Hochberg correction for multiple testing
+        /// Neg_PValue_Corrected - The afforementioned negative p-value, constraint-wise adjusted with the Benjamini-Hochberg correction for multiple testing
         ///
-        /// isAnySig_BH_Corrected - Indicates if the FAS can be considered as significantly enriched when looking at either negative or positive weights depending on the user defined alpha level
+        /// isAnySig_Corrected - Indicates if the FAS can be considered as significantly enriched when looking at either negative or positive weights depending on the user defined alpha level
         ///
         /// isAnySig - Indicates if the FAS can be considered as significantly enriched when looking at either negative or positive weights depending on the user defined alpha level after applying constraint-wise adjustment with the Benjamini-Hochberg correction for multiple testing
         ///
@@ -143,14 +173,15 @@ module Frames =
         /// <param name="MinBinSize">A threshold for the amount of entities contained in every FAS. FAS below this entity count will not be contained in the result frame. Default=0</param>
         /// <param name="AlphaLevel">The alpha level to either accept or reject the FAS as significantly enriched. Default=0.05</param>
         /// <param name="TermNameTransformation">A function to transform the FAS Names</param>
-        static member toTMEACharacterizationFrame(?MinBinSize:int, ?AlphaLevel:float, ?TermNameTransformation:string->string) = 
+        static member toTMEACharacterizationFrame(?MinBinSize:int, ?AlphaLevel:float, ?TermNameTransformation:string->string,?CorrectionMethod:MultipleTestingCorrection) = 
             
             let minBinSize = defaultArg MinBinSize 0
+            let correctionMethod = defaultArg CorrectionMethod BenjaminiHochberg
             let alphaLevel = defaultArg AlphaLevel 0.05
             let termNameTransformation = defaultArg TermNameTransformation id
 
             fun (tmeaRes: TMEAResult) ->
-                tmeaRes.Characterizations |> createTMEACharacterizationTable minBinSize alphaLevel termNameTransformation
+                tmeaRes.Characterizations |> createTMEACharacterizationTable minBinSize alphaLevel termNameTransformation correctionMethod
 
         /// <summary>
         /// Returns a function that creates a frame containing A matrix that contains 1(indicating significant enrichment) or 0(indicating no enrichment) for all FAS(rows) in all constraints(columns)
@@ -158,9 +189,9 @@ module Frames =
         /// <param name="UseBenjaminiHochberg">Wether to use p-values adjusted by constraint-wise Benjamini-Hochberg correction for multiple testing. Default=false</param>
         /// <param name="AlphaLevel">The alpha level to either accept or reject the FAS as significantly enriched. Default=0.05</param>
         /// <param name="TermNameTransformation">A function to transform the FAS Names</param>
-        static member toSignificanceMatrixFrame (?UseBenjaminiHochberg:bool, ?AlphaLevel:float, ?TermNameTransformation:string->string) =
+        static member toSignificanceMatrixFrame (?CorrectionMethod:MultipleTestingCorrection, ?AlphaLevel:float, ?TermNameTransformation:string->string) =
             
-            let useBenjaminiHochberg = defaultArg UseBenjaminiHochberg false
+            let correctionMethod = defaultArg CorrectionMethod BenjaminiHochberg
             let threshold = defaultArg AlphaLevel 0.05
             let termNameTransformation = defaultArg TermNameTransformation id
 
@@ -180,24 +211,34 @@ module Frames =
                         )
             
                     let keys, pos' =
-                        if useBenjaminiHochberg then
-                            pos
-                            |> FSharp.Stats.Testing.MultipleTesting.benjaminiHochbergFDRBy id
-                            |> Array.ofList
-                            |> Array.unzip
-                        else
-                            pos
-                            |> Array.unzip
-            
+                        match correctionMethod with
+                            | NoCorrection -> Array.unzip pos
+                            | BenjaminiHochberg -> 
+                                pos
+                                |> FSharp.Stats.Testing.MultipleTesting.benjaminiHochbergFDRBy id
+                                |> Array.ofList
+                                |> Array.unzip
+                            
+                            | QValues -> 
+                                let id,pv = Array.unzip pos
+                                let pi0 = Testing.MultipleTesting.Qvalues.pi0Bootstrap pv
+                                let qv = Testing.MultipleTesting.Qvalues.ofPValues pi0 pv
+                                id,qv
+
                     let keys, neg' =
-                        if useBenjaminiHochberg then
-                            neg
-                            |> FSharp.Stats.Testing.MultipleTesting.benjaminiHochbergFDRBy id
-                            |> Array.ofList
-                            |> Array.unzip
-                        else
-                            neg
-                            |> Array.unzip
+                        match correctionMethod with
+                            | NoCorrection -> Array.unzip neg
+                            | BenjaminiHochberg -> 
+                                pos
+                                |> FSharp.Stats.Testing.MultipleTesting.benjaminiHochbergFDRBy id
+                                |> Array.ofList
+                                |> Array.unzip
+                            
+                            | QValues -> 
+                                let id,pv = Array.unzip neg
+                                let pi0 = Testing.MultipleTesting.Qvalues.pi0Bootstrap pv
+                                let qv = Testing.MultipleTesting.Qvalues.ofPValues pi0 pv
+                                id,qv
             
             
                     $"C_{cI}" => (

--- a/src/TMEA/Frames.fs
+++ b/src/TMEA/Frames.fs
@@ -174,19 +174,19 @@ module Frames =
                         )
             
                     let neg = 
-                        c.PositiveDescriptor
+                        c.NegativeDescriptor
                         |> Array.map (fun d ->
                             d.OntologyTerm => d.PValue
                         )
             
                     let keys, pos' =
                         if useBenjaminiHochberg then
-                            neg
+                            pos
                             |> FSharp.Stats.Testing.MultipleTesting.benjaminiHochbergFDRBy id
                             |> Array.ofList
                             |> Array.unzip
                         else
-                            neg
+                            pos
                             |> Array.unzip
             
                     let keys, neg' =

--- a/src/TMEA/IO.fs
+++ b/src/TMEA/IO.fs
@@ -181,11 +181,11 @@ module IO =
         ///
         /// Total_BinSize - The amount of entities contained in the FAS
         ///
-        /// Pos_PValue_BH_Corrected - The afforementioned positive p-value, constraint-wise adjusted with the Benjamini-Hochberg correction for multiple testing
+        /// Pos_PValue_Corrected - The afforementioned positive p-value, constraint-wise adjusted with the Benjamini-Hochberg correction for multiple testing
         ///
-        /// Neg_PValue_BH_Corrected - The afforementioned negative p-value, constraint-wise adjusted with the Benjamini-Hochberg correction for multiple testing
+        /// Neg_PValue_Corrected - The afforementioned negative p-value, constraint-wise adjusted with the Benjamini-Hochberg correction for multiple testing
         ///
-        /// isAnySig_BH_Corrected - Indicates if the FAS can be considered as significantly enriched when looking at either negative or positive weights depending on the user defined alpha level
+        /// isAnySig_Corrected - Indicates if the FAS can be considered as significantly enriched when looking at either negative or positive weights depending on the user defined alpha level
         ///
         /// isAnySig - Indicates if the FAS can be considered as significantly enriched when looking at either negative or positive weights depending on the user defined alpha level after applying constraint-wise adjustment with the Benjamini-Hochberg correction for multiple testing
         ///
@@ -194,12 +194,12 @@ module IO =
         /// <param name="MinBinSize">A threshold for the amount of entities contained in every FAS. FAS below this entity count will not be contained in the result frame. Default=0</param>
         /// <param name="AlphaLevel">The alpha level to either accept or reject the FAS as significantly enriched. Default=0.05</param>
         /// <param name="TermNameTransformation">A function to transform the FAS Names</param>
-        static member saveTMEACharacterizationFrame(path:string, ?MinBinSize:int, ?AlphaLevel:float, ?TermNameTransformation:string->string) = 
+        static member saveTMEACharacterizationFrame(path:string, ?MinBinSize:int, ?AlphaLevel:float, ?TermNameTransformation:string->string,?CorrectionMethod:MultipleTestingCorrection) = 
              
              fun (tmeaRes: TMEAResult) ->
                 tmeaRes
-                |> TMEAResult.toTMEACharacterizationFrame(?MinBinSize=MinBinSize, ?AlphaLevel=AlphaLevel, ?TermNameTransformation=TermNameTransformation)
-                |> fun f -> f.SaveCsv(path,separator='\t',keyNames=["Term(FAS)"; "Transformed Term"; "ConstraintIndex"])
+                |> TMEAResult.toTMEACharacterizationFrame(?MinBinSize=MinBinSize, ?AlphaLevel=AlphaLevel, ?TermNameTransformation=TermNameTransformation,?CorrectionMethod=CorrectionMethod)
+                |> fun (f:Frame<(string*(string*int)),string>) -> f.SaveCsv(path,separator='\t',keyNames=["Term(FAS)"; "Transformed Term"; "ConstraintIndex"])
 
         /// <summary>
         /// Returns a function that saves a frame containing A matrix that contains 1(indicating significant enrichment) or 0(indicating no enrichment) for all FAS(rows) in all constraints(columns) at the given path.
@@ -208,11 +208,11 @@ module IO =
         /// <param name="UseBenjaminiHochberg">Wether to use p-values adjusted by constraint-wise Benjamini-Hochberg correction for multiple testing. Default=false</param>
         /// <param name="AlphaLevel">The alpha level to either accept or reject the FAS as significantly enriched. Default=0.05</param>
         /// <param name="TermNameTransformation">A function to transform the FAS Names</param>
-        static member saveSignificanceMatrixFrame(path:string, ?UseBenjaminiHochberg:bool, ?AlphaLevel:float, ?TermNameTransformation:string->string) =
+        static member saveSignificanceMatrixFrame(path:string, ?CorrectionMethod:MultipleTestingCorrection, ?AlphaLevel:float, ?TermNameTransformation:string->string) =
             
             fun (tmeaRes: TMEAResult) ->
                 tmeaRes
-                |> TMEAResult.toSignificanceMatrixFrame(?UseBenjaminiHochberg=UseBenjaminiHochberg, ?AlphaLevel=AlphaLevel, ?TermNameTransformation=TermNameTransformation)
+                |> TMEAResult.toSignificanceMatrixFrame(?CorrectionMethod=CorrectionMethod, ?AlphaLevel=AlphaLevel, ?TermNameTransformation=TermNameTransformation)
                 |> fun f -> f.SaveCsv(path,separator='\t',keyNames=["Term(FAS)"; "Transformed Term"])
 
         /// <summary>


### PR DESCRIPTION
When handling hundreds of functional annotated sets (FAS) the applied Benjamini-Hochberg correction may be too conservative. I've added the possibility to choose between
  1. No correction
  2. Benjamini Hochberg correction and
  3. QValue correction

Additionally I've fixed a bug that mixed up some results concerning the significance matrix creation.

- [x] The project builds without problems on my machine